### PR TITLE
:golf:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.3
-  - 2.2.0-preview1
+  - 2.0
+  - 2.1
+  - 2.2
   - ruby-head
 bundler_args: --jobs=2
 script: CODECLIMATE_REPO_TOKEN=8e9db6ee5f3818e87287a6393086c2ccb9b1b83106c5bfb972211abefd2fe162 bundle exec rspec --tag category:verbose && bundle exec rspec
@@ -13,5 +13,5 @@ notifications:
   email: false
 matrix:
   allow_failures:
-    - rvm: 2.2.0-preview1
+    - rvm: 2.2
     - rvm: ruby-head


### PR DESCRIPTION
Ruby "2.2" now points to 2.2.0-preview1, and "2.1" to 2.1.3 on .org. If you want to test older version, say "2.1.2" specifically.
https://twitter.com/travisci/statuses/513233940442644480
