### PR TITLE
Use unparser < 0.2.5 when ruby 2.0

### DIFF
--- a/rubicure.gemspec
+++ b/rubicure.gemspec
@@ -35,4 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-parameterized"
   spec.add_development_dependency "rubocop", "0.35.1"
   spec.add_development_dependency "yard"
+
+  if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
+    # NOTE: unparser v0.2.5 drop support ruby < 2.1
+    spec.add_development_dependency "unparser", "< 0.2.5"
+  end
 end


### PR DESCRIPTION
unparser v0.2.5 drop support ruby < 2.1
https://github.com/mbj/unparser/blob/master/Changelog.md#v025-2016-01-24