### PR TITLE
Drop support ruby 2.0 and 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-- 2.0
-- 2.1
-- 2.2
+- 2.2.2
 - 2.3.3
 - 2.4.0
 - ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -3,22 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rubicure.gemspec
 gemspec
 
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
-  # NOTE: build is failed when use ruby 2.0 and rspec-parameterized 0.3.0+
-  #   https://travis-ci.org/sue445/rubicure/jobs/114266855
-  gem "rspec-parameterized", "< 0.3.0", group: :test
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
-  # NOTE: unparser v0.2.5 drop support ruby < 2.1
-  gem "unparser", "< 0.2.5", group: :test
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
-  # NOTE: activesupport 5.x supports only ruby 2.2.2+
-  gem "activesupport", ">= 4.0.0", "< 5.0.0"
-end
-
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.3.0")
   gem "backport_dig"
 end

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Inspired by [Acme::PrettyCure](http://perl-users.jp/articles/advent-calendar/201
 
 ## Requirements
 
-* ruby >= 2.0.0
+* ruby >= 2.2.2
   * more: [.travis.yml](.travis.yml)
 
 ## Installation
@@ -32,7 +32,7 @@ Add this line to your application's Gemfile:
 ```ruby
 gem 'rubicure'
 
-# for ruby 2.0, 2.1, 2.2
+# for ruby 2.2
 gem 'backport_dig'
 ```
 

--- a/rubicure.gemspec
+++ b/rubicure.gemspec
@@ -13,14 +13,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/rubicure"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.2.2"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 4.0.0"
+  spec.add_dependency "activesupport", ">= 5.0.0"
   spec.add_dependency "hashie", ">= 2.0.5"
   spec.add_dependency "sengiri_yaml", ">= 0.0.2"
 

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -44,32 +44,32 @@ describe Rubicure::Core do
     context "With arg" do
       subject { instance.all_stars(arg) }
 
+      using RSpec::Parameterized::TableSyntax
+
       where(:arg, :expected_count, :include_cure_echo) do
-        [
-          ["2009-03-20",             14, false],
-          [Date.parse("2010-03-20"), 17, false],
-          [Time.parse("2011-03-19"), 21, false],
+        "2009-03-20"             | 14 | false
+        Date.parse("2010-03-20") | 17 | false
+        Time.parse("2011-03-19") | 21 | false
 
-          [:dx,         14, false],
-          [:dx1,        14, false],
-          [:dx2,        17, false],
-          [:dx3,        21, false],
+        :dx  | 14 | false
+        :dx1 | 14 | false
+        :dx2 | 17 | false
+        :dx3 | 21 | false
 
-          [:ns,         29, true],
-          [:ns1,        29, true],
-          [:new_stage,  29, true],
-          [:new_stage1, 29, true],
-          [:ns2,        32, false],
-          [:new_stage2, 32, false],
-          [:ns3,        37, true],
-          [:new_stage3, 37, true],
+        :ns         | 29 | true
+        :ns1        | 29 | true
+        :new_stage  | 29 | true
+        :new_stage1 | 29 | true
+        :ns2        | 32 | false
+        :new_stage2 | 32 | false
+        :ns3        | 37 | true
+        :new_stage3 | 37 | true
 
-          [:sc,              40, false],
-          [:spring_carnival, 40, false],
+        :sc              | 40 | false
+        :spring_carnival | 40 | false
 
-          [:stmm,                        44, true],
-          [:sing_together_miracle_magic, 44, true],
-        ]
+        :stmm                        | 44 | true
+        :sing_together_miracle_magic | 44 | true
       end
 
       with_them do


### PR DESCRIPTION
# Why?
* [Precure Allstars](http://www.precure-allstars.com/) change to [Precure Dreamstars](http://www.precure-dreamstars.com/)
* Ruby 2.0 is already retired
* Ruby 2.1 will be retired after ruby 2.4 release