### PR TITLE
同じ必殺技が被ってしまっていたので削除

### DIFF
--- a/config/girls/010_dokidoki.yml
+++ b/config/girls/010_dokidoki.yml
@@ -18,8 +18,6 @@ cure_heart: &cure_heart
   attack_messages:
     - |-
       あなたに届け！マイスイートハート！
-    - |-
-      あなたに届け！マイスイートハート！
   transform_calls:
     - love_link
 cure_diamond: &cure_diamond


### PR DESCRIPTION
ほかのドキドキ！プリキュアの`attack_messages`がそうはなっていなかったので修正しました。
何か勘違いしていればすみません。