### PR TITLE
Apply line breaks to the transform messages.

### DIFF
--- a/config/girls/013_maho_girls.yml
+++ b/config/girls/013_maho_girls.yml
@@ -92,7 +92,7 @@ cure_magical: &cure_magical
       precure_name: キュアマジカル（ダイヤスタイル）
       color:        blue
       created_date: 2016-02-07 # episode 1
-      transform_message:
+      transform_message: |-
         キュアップ・ラパパ！　ダイヤ！
         ミラクル・マジカル・ジュエリーレ！
         ふたりの魔法！キュアマジカル！
@@ -108,7 +108,7 @@ cure_magical: &cure_magical
       precure_name: キュアマジカル（ルビースタイル）
       color:        red
       created_date: 2016-02-21 # episode 3
-      transform_message:
+      transform_message: |-
         キュアップ・ラパパ！　ルビー！
         ミラクル・マジカル・ジュエリーレ！
         ふたりの魔法！キュアマジカル！


### PR DESCRIPTION
一部の変身メッセージに関してYAMLの[Block Chomping Indicator](http://www.yaml.org/spec/1.2/spec.html#id2794534)が省略されており、`transform!`時のメッセージに改行が含まれず、即時表示されるようになっていたので、修正いたしました。