### PR TITLE
Hash#fetch method is used instead of dig.

### DIFF
--- a/lib/rubicure/girl.rb
+++ b/lib/rubicure/girl.rb
@@ -92,7 +92,7 @@ module Rubicure
     ATTRIBUTES.each do |attribute|
       define_method attribute do
         if @current_transform_style
-          dig(:transform_styles, @current_transform_style, attribute) || self[attribute]
+          fetch(:transform_styles, {}).fetch(@current_transform_style, {})[attribute] || self[attribute]
         else
           self[attribute]
         end


### PR DESCRIPTION
girls.rbで[Hash#dig](https://www.google.co.jp/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=hash%20dig)が使われていますが、こちらのメソッドは2.3.0からになるようです。現状ですと2.2.0の動作が下記のようになり、動かなく。。
@sue445 さんのお好みでご判断いただければと思いますが、この箇所以外にdigが使われているところは無さそうなので、こちらご検討いただけると助かります。

```
$ irb -r rubicure
irb(main):001:0> mirai = Cure.magical
(中略)
irb(main):002:0> mirai.transform! :diamond
SystemStackError: stack level too deep
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:200:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
... 9313 levels...
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:206:in `method_missing'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:95:in `block (2 levels) in <class:Girl>'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:31:in `state_names'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:181:in `inc_current_state'
        from /Users/greymd/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rubicure-0.4.12/lib/rubicure/girl.rb:54:in `transform!'
        from (irb):2greymd
        from /Users/greymd/.rbenv/versions/2.2.0/bin/irb:11:in `<main>'irb(main):003:0>
(中略)
```