### PR TITLE
Rename: human name of cure princess

### DIFF
--- a/config/girls/011_happiness_charge.yml
+++ b/config/girls/011_happiness_charge.yml
@@ -37,7 +37,7 @@ cure_lovely: &cure_lovely
     - kururin_mirror_change
 cure_princess: &cure_princess
   girl_name:    cure_princess
-  human_name:   白雪ひめ(ヒメルダ・ウインドウ・キュアクイーン・オブ・ザ・ブルースカイ)
+  human_name:   白雪ひめ
   precure_name: キュアプリンセス
   cast_name:    潘めぐみ
   created_date: 2014-02-02 # episode 1


### PR DESCRIPTION
Official name is "白雪ひめ"
http://www.toei-anim.co.jp/tv/happinesscharge_precure/character/precure_cureprincess.php