### PR TITLE
Exclude examples/ from gem file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## master
 [full changelog](http://github.com/sue445/rubicure/compare/v0.4.13...master)
 
+* Exclude examples/ from gem file
+  * https://github.com/sue445/rubicure/pull/140
+
 ## v0.4.13
 [full changelog](http://github.com/sue445/rubicure/compare/v0.4.12...v0.4.13)
 

--- a/rubicure.gemspec
+++ b/rubicure.gemspec
@@ -16,6 +16,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+
+  %w(examples/).each do |exclude_dir|
+    spec.files.reject! { |filename| filename.start_with?(exclude_dir) }
+  end
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This is unnecessary for running

# Before
```sh
$ bundle exec rake build

$ ls -l pkg/
total 992
-rw-r--r--  1 sue445  staff  506880  1 28 01:40 rubicure-0.4.13.gem
```

# After
```sh
$ bundle exec rake build

$ ls -l pkg/
total 80
-rw-r--r--  1 sue445  staff  38912  1 28 01:45 rubicure-0.4.13.gem
```
