### PR TITLE
Impl Precure.dream_stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,15 @@ Precure.all_girls.include?(Cure.echo)
 * `Precure.all_girls` returns all precure. (includes "Kirakira Precure Alamode")
 * `Precure.all_stars` returns only from "Futari wa Pretty Cure" to "Maho Girls PreCure"
 
+### `Precure.dream_stars`
+```ruby
+Precure.dream_stars.count
+#=> 12
+
+Precure.dream_stars.map(&:precure_name)
+#=> ["キュアフローラ", "キュアマーメイド", "キュアトゥインクル", "キュアスカーレット", "キュアミラクル", "キュアマジカル", "キュアフェリーチェ", "キュアホイップ", "キュアカスタード", "キュアジェラート", "キュアマカロン", "キュアショコラ"]
+```
+
 ### Equivalence
 ```ruby
 yayoi = Cure.peace.dup

--- a/config/movies.yml
+++ b/config/movies.yml
@@ -52,3 +52,9 @@ stmm: &stmm
   - cure_echo
 sing_together_miracle_magic:
   <<: *stmm
+#######################################################
+dream_stars: &dream_stars
+  title: 映画プリキュアドリームスターズ！
+  started_date: 2017-03-18
+dc:
+  <<: *dream_stars

--- a/lib/rubicure/core.rb
+++ b/lib/rubicure/core.rb
@@ -77,6 +77,16 @@ module Rubicure
 
     alias_method :all, :all_girls
 
+    def dream_stars
+      return @dream_stars if @dream_stars
+      girls = Precure.go_princess.girls + Precure.maho_girls.girls + Precure.a_la_mode.girls
+
+      dream_stars_date = Rubicure::Movie.find(:dream_stars).started_date
+      @dream_stars = girls.select { |girl| girl.created_date && girl.created_date <= dream_stars_date }
+
+      @dream_stars
+    end
+
     # iterate with :unmarked, :max_heart, ...
     #
     # @yield series

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -108,4 +108,27 @@ describe Rubicure::Core do
       end
     end
   end
+
+  describe "#dream_stars" do
+    subject { Precure.dream_stars.map(&:girl_name) }
+
+    let(:dream_stars_girl_names) do
+      [
+        Cure.flora,
+        Cure.mermaid,
+        Cure.twinkle,
+        Cure.scarlet,
+        Cure.miracle,
+        Cure.magical,
+        Cure.felice,
+        Cure.whip,
+        Cure.custard,
+        Cure.gelato,
+        Cure.macaroon,
+        Cure.chocolat,
+      ].map(&:girl_name)
+    end
+
+    it { should contain_exactly(*dream_stars_girl_names) }
+  end
 end

--- a/spec/movie_spec.rb
+++ b/spec/movie_spec.rb
@@ -9,6 +9,7 @@ describe Rubicure::Movie do
       :ns3,
       :sc,
       :stmm,
+      :dream_stars,
     ]
   end
 


### PR DESCRIPTION
```ruby
Precure.dream_stars.count
#=> 12

Precure.dream_stars.map(&:precure_name)
#=> ["キュアフローラ", "キュアマーメイド", "キュアトゥインクル", "キュアスカーレット", "キュアミラクル", "キュアマジカル", "キュアフェリーチェ", "キュアホイップ", "キュアカスタード", "キュアジェラート", "キュアマカロン", "キュアショコラ"]
```


Close #137