### PR TITLE
Support did_you_mean

### DIFF
--- a/lib/rubicure.rb
+++ b/lib/rubicure.rb
@@ -15,15 +15,9 @@ begin
 rescue LoadError
 end
 
-module Rubicure
-  def self.core
-    Rubicure::Core.instance
-  end
-end
-
 module Precure
   def self.method_missing(name, *args, &block)
-    Rubicure.core.send(name, *args, &block)
+    Rubicure::Core.instance.send(name, *args, &block)
   end
 end
 

--- a/lib/rubicure/core.rb
+++ b/lib/rubicure/core.rb
@@ -7,12 +7,16 @@ module Rubicure
     include Enumerable
     include Rubicure::Concerns::Util
 
+    Rubicure::Series.names.each do |series_name|
+      define_method series_name do
+        Rubicure::Series.find(series_name)
+      end
+    end
+
     def method_missing(name, *args)
       unmarked_precure = Rubicure::Series.find(:unmarked)
 
-      if Rubicure::Series.valid?(name)
-        Rubicure::Series.find(name)
-      elsif unmarked_precure.respond_to?(name)
+      if unmarked_precure.respond_to?(name)
         unmarked_precure.send(name, *args)
       else
         super

--- a/lib/rubicure/cure.rb
+++ b/lib/rubicure/cure.rb
@@ -1,9 +1,7 @@
 module Cure
-  def self.method_missing(name, *args)
-    if Rubicure::Girl.valid?(name)
-      Rubicure::Girl.find(name)
-    else
-      super
+  Rubicure::Girl.names.each do |girl_name|
+    define_singleton_method girl_name do
+      Rubicure::Girl.find(girl_name)
     end
   end
 


### PR DESCRIPTION
# Example
```
irb(main):001:0> Cure.macaroon
NoMethodError: undefined method `macaroon' for Cure:Module
Did you mean?  macaron
	from (irb):1
	from /Users/sue445/.rbenv/versions/2.4.0/bin/irb:11:in `<top (required)>'
	from /Users/sue445/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.3/lib/bundler/cli/exec.rb:74:in `load'
	from /Users/sue445/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
	from /Users/sue445/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.14.3/lib/bundler/cli/exec.rb:27:in `run'

irb(main):002:0> Precure.a_ra_mode
NoMethodError: undefined method `a_ra_mode' for #<Rubicure::Core:0x007fdaca2c9870>
Did you mean?  a_la_mode
               alamode
	from /Users/sue445/dev/workspace/github.com/sue445/rubicure/lib/rubicure/core.rb:22:in `method_missing'
	from /Users/sue445/dev/workspace/github.com/sue445/rubicure/lib/rubicure.rb:26:in `method_missing'
	from (irb):2
```