### PR TITLE
Bugfix: Girls of Hugtto precure returns empty birthday despite `#has_birthday?` returns true

### DIFF
--- a/config/girls/015_hugtto.yml
+++ b/config/girls/015_hugtto.yml
@@ -5,7 +5,7 @@ cure_yell: &cure_yell
   cast_name:    引坂理絵
   color:        pink
   created_date: 2018-02-04 # episode 1
-  birthday:
+  # birthday:
   transform_message: |-
     ミライクリスタル！
     ハートキラっと！
@@ -30,7 +30,7 @@ cure_ange: &cure_ange
   cast_name:    本泉莉奈
   color:        blue
   created_date: 2018-02-11 # episode 2
-  birthday:
+  # birthday:
   transform_message: |-
     ミライクリスタル！
     ハートキラっと！
@@ -55,7 +55,7 @@ cure_etoile: &cure_etoile
   cast_name:    小倉唯
   color:        yellow
   created_date: 2018-03-04 # episode 5
-  birthday:
+  # birthday:
   transform_message: |-
     ミライクリスタル！
     ハートキラっと！

--- a/spec/config/girls_checker_spec.rb
+++ b/spec/config/girls_checker_spec.rb
@@ -23,6 +23,19 @@ describe "girls_checker" do # rubocop:disable RSpec/DescribeClass
               end
             end
           end
+
+          describe "#birthday" do
+            context "has birthday", if: girl.has_key?("birthday") do
+              birthday = girl["birthday"]
+
+              it { expect(birthday).not_to be_blank }
+
+              it "'#{birthday}' is valid date" do
+                ymd = "#{Date.today.year}/#{birthday}"
+                expect(Date.parse(ymd)).to be_a Date
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
```ruby
irb(main):001:0> nonohana = Cure.yell

irb(main):002:0> nonohana.have_birthday?
#=> true

irb(main):003:0> nonohana.birthday
#=> nil
```