### PR TITLE
Resolved rubocop offenses

### DIFF
--- a/lib/rubicure/core.rb
+++ b/lib/rubicure/core.rb
@@ -28,6 +28,8 @@ module Rubicure
       unmarked_precure.respond_to?(name)
     end
 
+    # rubocop:disable Metrics/LineLength
+
     # get current precure series
     # @return [Rubicure::Series] current precure
     #
@@ -43,6 +45,7 @@ module Rubicure
       end
       raise NotOnAirError, "Not on air precure!"
     end
+    # rubocop:enable Metrics/LineLength
 
     alias_method :current, :now
 


### PR DESCRIPTION
```
Offenses:

lib/rubicure/core.rb:38:161: C: Metrics/LineLength: Line is too long. [171/160]
    #   #=> {:series_name=>"go_princess", :title=>"Go!プリンセスプリキュア", :started_date=>Sun, 01 Feb 2015, :girls=>["cure_flora", "cure_mermaid", "cure_twinkle", "cure_scarlet"]}
                                                                                                                                                                ^^^^^^^^^^^

25 files inspected, 1 offense detected
```