### PR TITLE
Fixed. `Precure.hugtto` doesn't contains macherie and amour

### DIFF
--- a/config/series.yml
+++ b/config/series.yml
@@ -199,5 +199,7 @@ hugtto: &hugtto
   - cure_yell
   - cure_ange
   - cure_etoile
+  - cure_macherie
+  - cure_amour
 hugtto_precure:
   <<: *hugtto


### PR DESCRIPTION
# Before
```ruby
Precure.hugtto.girls.map(&:precure_name)
#=> ["キュアエール", "キュアアンジュ", "キュアエトワール"]
```

# After
```ruby
Precure.hugtto.girls.map(&:precure_name)
#=> ["キュアエール", "キュアアンジュ", "キュアエトワール", "キュアマシェリ", "キュアアムール"]
```
