### PR TITLE
Drop support for ruby 2.2 and 2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
 
       matrix:
         ruby:
-          - ruby:2.2
-          - ruby:2.3
           - ruby:2.4
           - ruby:2.5
           - ruby:2.6
@@ -64,7 +62,6 @@ jobs:
         with:
           codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
           command: before-build
-        if: matrix.ruby >= 'ruby:2.4'
         continue-on-error: true
 
       - run: bundle exec rspec
@@ -80,7 +77,7 @@ jobs:
         with:
           codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
           command: after-build
-        if: matrix.ruby >= 'ruby:2.4' && always()
+        if: always()
         continue-on-error: true
 
       - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,14 +4,10 @@ inherit_gem:
     - "config/rspec.yml"
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
 
 RSpec/NestedGroups:
   Enabled: false
 
 RSpec/SharedExamples:
-  Enabled: false
-
-# TODO: Remove when drop support ruby 2.2
-Layout/IndentHeredoc:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,25 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rubicure.gemspec
 gemspec
 
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.3.0")
-  gem "backport_dig"
-
-  # i18n v1.5.1+ requires Ruby 2.3.0+
-  gem "i18n", "< 1.5.1"
-
-  # N0TE: unparser v0.5.0+ requires ruby 2.3.0+
-  gem "unparser", "< 0.5.0"
-end
-
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.5.0")
   # activesupport v6.0.0+ requires Ruby 2.5.0+
   gem "activesupport", "< 6.0.0"
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.4.0")
-  # byebug v11.0.0+ requires Ruby 2.3.0+ and byebug v11.1.0+ requires Ruby 2.4.0+
-  gem "byebug", "< 11.0.0"
-
-  # simplecov-html 0.11.0+ requires Ruby 2.4.0
-  gem "simplecov-html", "< 0.11.0"
 end

--- a/examples/all.rb
+++ b/examples/all.rb
@@ -1,26 +1,26 @@
 require "rubicure"
 
 Precure.each_with_series do |series|
-  puts <<MESSAGE
-====================
-title:     #{series.title}
-broadcast: #{series.started_date} - #{series.try(:ended_date)}
-girls:     #{series.girls.count}
+  puts <<~MESSAGE
+    ====================
+    title:     #{series.title}
+    broadcast: #{series.started_date} - #{series.try(:ended_date)}
+    girls:     #{series.girls.count}
 MESSAGE
 
   series.girls.each do |girl|
-    puts <<MESSAGE
-------------------------
-  human_name:      #{girl.human_name}
-  human_full_name: #{girl.human_full_name}
-  precure_name:    #{girl.precure_name}
-  cast_name:       #{girl.cast_name}
-  color:           #{girl.color}
-  extra_names:     #{girl[:extra_names]}
-  state_names:     #{girl.state_names}
-  attack_messages: #{girl.attack_messages}
-  transform_message:
-#{girl.transform_message}
+    puts <<~MESSAGE
+      ------------------------
+        human_name:      #{girl.human_name}
+        human_full_name: #{girl.human_full_name}
+        precure_name:    #{girl.precure_name}
+        cast_name:       #{girl.cast_name}
+        color:           #{girl.color}
+        extra_names:     #{girl[:extra_names]}
+        state_names:     #{girl.state_names}
+        attack_messages: #{girl.attack_messages}
+        transform_message:
+      #{girl.transform_message}
 MESSAGE
   end
 end

--- a/lib/rubicure/cure_peace.rb
+++ b/lib/rubicure/cure_peace.rb
@@ -9,7 +9,7 @@
       ピカピカピカリン
       ジャンケンポン！
       （%s）
-JANKEN
+    JANKEN
     def pikarin_janken
       print_by_line(MESSAGE % HANDS.sample)
     end

--- a/lib/rubicure/cure_peace.rb
+++ b/lib/rubicure/cure_peace.rb
@@ -5,10 +5,10 @@
       (["チョキ"] * 14) +
       (["パー"] * 15) +
       ["グッチョッパー"]
-    MESSAGE = <<JANKEN.freeze
-ピカピカピカリン
-ジャンケンポン！
-（%s）
+    MESSAGE = <<~JANKEN.freeze
+      ピカピカピカリン
+      ジャンケンポン！
+      （%s）
 JANKEN
     def pikarin_janken
       print_by_line(MESSAGE % HANDS.sample)

--- a/rubicure.gemspec
+++ b/rubicure.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-parameterized", ">= 0.3.2"
   spec.add_development_dependency "rubocop", "0.53.0"
   spec.add_development_dependency "rubocop-rspec", "1.25.1"
+  spec.add_development_dependency "rubocop_auto_corrector"
   spec.add_development_dependency "rubydoctest"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "unparser", ">= 0.4.5"

--- a/rubicure.gemspec
+++ b/rubicure.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/rubicure"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.2.2"
+  spec.required_ruby_version = ">= 2.4"
 
   if spec.respond_to?(:metadata)
     spec.metadata["homepage_uri"] = spec.homepage

--- a/spec/rubicure/girl_spec.rb
+++ b/spec/rubicure/girl_spec.rb
@@ -25,10 +25,10 @@ describe Rubicure::Girl do
   let(:extra_names)    { %w[プリンセスピース ウルトラピース] }
   let(:color)          { "yellow" }
   let(:transform_message) do
-    <<JANKEN
-プリキュアスマイルチャージ！
-GO! GO! Let's GO ピース！
-ピカピカピカリンジャンケンポン！ キュアピース！
+    <<~JANKEN
+      プリキュアスマイルチャージ！
+      GO! GO! Let's GO ピース！
+      ピカピカピカリンジャンケンポン！ キュアピース！
 JANKEN
   end
   let(:attack_messages) do

--- a/spec/rubicure/girl_spec.rb
+++ b/spec/rubicure/girl_spec.rb
@@ -29,7 +29,7 @@ describe Rubicure::Girl do
       プリキュアスマイルチャージ！
       GO! GO! Let's GO ピース！
       ピカピカピカリンジャンケンポン！ キュアピース！
-JANKEN
+  JANKEN
   end
   let(:attack_messages) do
     [

--- a/spec/rubicure/series_spec.rb
+++ b/spec/rubicure/series_spec.rb
@@ -148,8 +148,8 @@ describe Rubicure::Series do
     let(:series_name) { :splash_star }
 
     let(:json) do
-      <<-JSON
-{\"series_name\":\"splash_star\",\"title\":\"ふたりはプリキュア Splash☆Star\",\"started_date\":\"2006-02-05\",\"ended_date\":\"2007-01-28\",\"girls\":[\"cure_bloom\",\"cure_egret\"]}
+      <<~JSON
+        {\"series_name\":\"splash_star\",\"title\":\"ふたりはプリキュア Splash☆Star\",\"started_date\":\"2006-02-05\",\"ended_date\":\"2007-01-28\",\"girls\":[\"cure_bloom\",\"cure_egret\"]}
       JSON
     end
 


### PR DESCRIPTION
I want to upgrade rubocop, but latest rubocop requires Ruby 2.4+
https://rubygems.org/gems/rubocop/versions/1.7.0

Ruby 2.2 and 2.3 are retired before 2 years ago. So I dropped these versions.
https://www.ruby-lang.org/en/downloads/branches/
