### PR TITLE
Remove needless require

### DIFF
--- a/lib/rubicure.rb
+++ b/lib/rubicure.rb
@@ -20,11 +20,6 @@ require "rubicure/cure_passion"
 require "rubicure/cure_beat"
 require "rubicure/cure_scarlet"
 
-begin
-  require "backport_dig"
-rescue LoadError # rubocop:disable Lint/SuppressedException
-end
-
 module Precure
   def self.method_missing(name, *args, &block)
     Rubicure::Core.instance.send(name, *args, &block)


### PR DESCRIPTION
backport_dig is gem for Ruby < 2.3. But current rubicure requires Ruby 2.4+