### PR TITLE
Requires Ruby 2.7+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
 
       matrix:
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
@@ -41,23 +40,13 @@ jobs:
           - activesupport_7_2
           - activesupport_8_0
         exclude:
-          # activesupport 7.0+ requires Ruby 2.7+
-          - ruby:    "2.6"
-            gemfile: activesupport_7_0
-          - ruby:    "2.6"
-            gemfile: activesupport_7_1
-
           # activesupport 7.2+ requires Ruby 3.1+
-          - ruby:    "2.6"
-            gemfile: activesupport_7_2
           - ruby:    "2.7"
             gemfile: activesupport_7_2
           - ruby:    "3.0"
             gemfile: activesupport_7_2
 
           # activesupport 8.0+ requires Ruby 3.2+
-          - ruby:    "2.6"
-            gemfile: activesupport_8_0
           - ruby:    "2.7"
             gemfile: activesupport_8_0
           - ruby:    "3.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ inherit_gem:
     - "config/performance.yml"
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: "2.7"
   NewCops: enable
 
   Exclude:

--- a/rubicure.gemspec
+++ b/rubicure.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/rubicure"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Now, latest rubocop requires Ruby 2.7+

c.f. https://rubygems.org/gems/rubocop/versions/1.69.2

So I want to drop ruby 2.6